### PR TITLE
Issue-7 Configured circleci to publish new version to rubygems.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,35 @@ jobs:
       - store_test_results:
           path: test_results
 
+  publish_to_rubygems:
+    working_directory: ~/repos/ping
+
+    docker:
+      - image: circleci/ruby:2.6.4-buster-node
+        environment:
+          <<: *environment
+
+    steps:
+      - checkout
+
+      - run:
+          name: setup Rubygems
+          command: bash .circleci/setup-rubygems.sh
+
+      - run:
+          name: publish to Rubygems
+          command: |
+            gem build ping.gemspec
+            gem push "ping-$(git describe --tags).gem"
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - functional_tests
+      - publish_to_rubygems:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/setup-rubygems.sh
+++ b/.circleci/setup-rubygems.sh
@@ -1,0 +1,3 @@
+mkdir ~/.gem
+echo -e "---\r\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
+chmod 0600 /home/circleci/.gem/credentials


### PR DESCRIPTION
resolves #7

Need to delete tag  v0.1.0 
use `git push origin 0.1.0` to publish the gem to rubygems.org
Need to add key `RUBYGEMS_API_KEY` on circleci 
 